### PR TITLE
just a little misspelled/typo word

### DIFF
--- a/data/part-1/2-printing.md
+++ b/data/part-1/2-printing.md
@@ -548,4 +548,4 @@ public class Comments {
 }
 ```
 
-The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to eb deleted to try out something else.
+The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to be deleted to try out something else.


### PR DESCRIPTION

![1-2b1 printing](https://user-images.githubusercontent.com/24639417/78784407-95528780-79a5-11ea-8e4b-b6ffa67839b7.png)
![1-2b2 printing](https://user-images.githubusercontent.com/24639417/78784429-9c799580-79a5-11ea-8a6f-7ff045131f96.png)

instead of "to eb deleted", it should say "to be deleted" (in the last sentence, line 551)