### PR TITLE
small typos and (proposed) corrections

### DIFF
--- a/data/part-1/4-variables.md
+++ b/data/part-1/4-variables.md
@@ -533,7 +533,7 @@ Letters containing diacritics (e.g. the letters ä and ö used in Finnish) shoul
 
 <!-- Muuttujan tyyppi kerrotaan muuttujan esittelyn yhteydessä. Esimerkiksi merkkijonon "teksti" sisältävä merkkijonomuuttuja luodaan lauseella `String merkkijono = "teksti";` ja kokonaisluvun 42 sisältävä kokonaislukumuuttuja luodaan lauseella `int luku = 42;`. -->
 
-A variable's type is specificed when it's initally declared. For example, a variable containing the string "text" is declared with the statement `String string = "text";`, and an integer having the value 42 is declared with the statement `int value = 42;`. -->
+A variable's type is specified when it's initally declared. For example, a variable containing the string "text" is declared with the statement `String string = "text";`, and an integer having the value 42 is declared with the statement `int value = 42;`. -->
 
 <!-- Muuttujan tyyppi määrää arvot, joita muuttuja voi saada. `String`-tyyppiset muuttujat saavat arvokseen merkkijonoja, `int`-tyyppiset muuttujat saavat arvokseen kokonaislukuja, `double`-tyyppiset muuttujat saavat arvokseen liukulukuja, ja `boolean`-tyyppiset muuttujat saavat arvokseen totuusarvoja. -->
 


### PR DESCRIPTION
√  (line 52): 'ourselves' instead of 'ourselvese'
√ (line 198): 'it is' instead of 'its'
√ (line 323): 'type' instead of 'tpe'
√ (line 536): 'specified' instead of 'specificed'