### PR TITLE
add correct logic regarding lower and upper limit!

### DIFF
--- a/data/part-2/3-more-loops.md
+++ b/data/part-2/3-more-loops.md
@@ -251,7 +251,7 @@ Where from? **5**
 </sample-output>
 
 <!-- Jos tavoite on suurempi kuin lähtökohta ei tulostu mitään: -->
-If the upper limit is larger than the starting point, nothing is printed:
+If the upper limit is smaller than the starting point, nothing is printed:
 
 <sample-output>
 


### PR DESCRIPTION
`3-more-loops.md`

`line 254`: logic is inverted!

~ It should say something like this:
"__If the upper limit is smaller than the starting point, nothing is printed:__"

_Google Translator_
"Jos tavoite on suurempi kuin lähtökohta ei tulostu mitään:"
"If the target is greater than the starting point, <strike>nothing</strike> is printed:" _<-- no, no, I don't think so!_ 😄 🤔 `if (low < end) { print }`
https://translate.google.com/?sl=fi&tl=en&text=Jos%20tavoite%20on%20suurempi%20kuin%20l%C3%A4ht%C3%B6kohta%20ei%20tulostu%20mit%C3%A4%C3%A4n&op=translate

![google-translator](https://user-images.githubusercontent.com/24639417/114434565-73e13880-9bc3-11eb-98c6-2a5b1f08dd44.png)

_Works Fine!_ OK! 👍

![Part2_16 FromWhereToWhere--works fine! OK!](https://user-images.githubusercontent.com/24639417/114436884-2b774a00-9bc6-11eb-86b3-5dd19ef73ed8.png)
